### PR TITLE
Solved the internal server error on patient managment system

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:system"
+}

--- a/code/meditriage-be/app/schemas/patient.py
+++ b/code/meditriage-be/app/schemas/patient.py
@@ -15,7 +15,7 @@ class PatientCreate(BaseModel):
     first_name: str = Field(..., min_length=1, max_length=100, description="First name")
     last_name: str = Field(..., min_length=1, max_length=100, description="Last name")
     date_of_birth: date = Field(..., description="Date of birth")
-    gender: Optional[Gender] = Field(None, description="Gender (MALE, FEMALE, OTHER)")
+    gender: Optional[Gender] = Field(None, description="Gender (MALE, FEMALE, PREFER_NOT_TO_SAY)")
     contact_number: Optional[str] = Field(None, max_length=20, description="Contact phone number")
 
 

--- a/code/meditriage-be/app/services/patient_service.py
+++ b/code/meditriage-be/app/services/patient_service.py
@@ -4,7 +4,7 @@ Business logic for patient management, search, and encounter history.
 """
 from uuid import UUID
 from typing import Optional, List
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.exc import IntegrityError
 from fastapi import HTTPException, status
 from app.models.patient import Patient
@@ -173,14 +173,32 @@ def soft_delete_patient(patient_id: UUID, db: Session) -> bool:
         
     Raises:
         HTTPException: 404 if patient not found
+        HTTPException: 409 if patient has existing encounter records
     """
     patient = get_patient_by_id(patient_id, db)
-    
-    # For now, we'll use hard delete since Patient model doesn't have is_active field
-    # TODO: Add is_active field to Patient model and implement soft delete
+
+    # Guard: prevent hard delete if patient has linked encounter records
+    # This avoids a foreign key IntegrityError from the database
+    encounter_count = db.query(MedicalEncounter).filter(
+        MedicalEncounter.patient_id == patient_id
+    ).count()
+
+    if encounter_count > 0:
+        logger.warning(
+            f"Delete blocked: patient id={patient_id} has {encounter_count} encounter(s)"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Cannot delete patient: {encounter_count} encounter record(s) exist. "
+                "Remove all encounters before deleting the patient."
+            )
+        )
+
+    # TODO: Add is_active field to Patient model and implement true soft delete
     db.delete(patient)
     db.commit()
-    
+
     logger.info(f"Patient deleted: id={patient_id}")
     return True
 
@@ -203,10 +221,19 @@ def get_patient_encounter_history(patient_id: UUID, db: Session) -> List[Encount
     # Verify patient exists
     get_patient_by_id(patient_id, db)
     
-    # Fetch all encounters for this patient with related data
-    encounters = db.query(MedicalEncounter).filter(
-        MedicalEncounter.patient_id == patient_id
-    ).order_by(MedicalEncounter.encounter_timestamp.desc()).all()
+    # Fetch all encounters for this patient with related data.
+    # Eager-load nurse and doctor to avoid DetachedInstanceError from lazy loading
+    # after the session context changes.
+    encounters = (
+        db.query(MedicalEncounter)
+        .filter(MedicalEncounter.patient_id == patient_id)
+        .options(
+            joinedload(MedicalEncounter.nurse),
+            joinedload(MedicalEncounter.doctor),
+        )
+        .order_by(MedicalEncounter.encounter_timestamp.desc())
+        .all()
+    )
     
     # Build summary list
     history = []


### PR DESCRIPTION
Problem
All patient endpoints (POST, GET, PUT, DELETE, /history) were returning 500 Internal Server Error due to multiple issues in the schema, service layer, and database.

Root Causes & Fixes
1. Missing gender column in database (primary cause of all 500s)
The initial Alembic migration (

a3ce348c0952_initial_schema.py
) omitted the gender column when creating the 

patients
 table. SQLAlchemy was generating SQL that referenced patients.gender, which didn't exist in the DB.

Fixed: Added gender enum column to the initial migration. Applied the column directly to the live DB via ALTER TABLE.
2. Incorrect 

Gender
 enum hint in schema (

schemas/patient.py
)
The gender field description said "OTHER" which doesn't exist in the 

Gender
 enum — the correct value is "PREFER_NOT_TO_SAY".

Fixed: Corrected field description to "Gender (MALE, FEMALE, PREFER_NOT_TO_SAY)".
3. DetachedInstanceError risk in encounter history (

patient_service.py
)

get_patient_encounter_history()
 accessed enc.nurse.full_name and enc.doctor.full_name via lazy-loaded relationships, which can fail with a DetachedInstanceError outside the session context.

Fixed: Added joinedload(MedicalEncounter.nurse) and joinedload(MedicalEncounter.doctor) to the query using sqlalchemy.orm.joinedload.
4. Hard delete crashes on FK constraint (

patient_service.py
)

soft_delete_patient()
 was performing a hard db.delete() with no guard. If a patient had linked encounters, PostgreSQL would raise an uncaught IntegrityError → 500.

Fixed: Added a pre-delete check — if any encounters exist for the patient, raises 409 Conflict with a descriptive message instead of crashing.
Files Changed

app/schemas/patient.py

app/services/patient_service.py

alembic/versions/a3ce348c0952_initial_schema.py
Testing
All patient endpoints verified working via Postman after fixes:

POST /api/v1/patients → 201 Created ✅
GET /api/v1/patients/search → 200 OK ✅
GET /api/v1/patients/{id} → 200 OK ✅
PUT /api/v1/patients/{id} → 200 OK ✅
GET /api/v1/patients/{id}/history → 200 OK (empty [] for new patients, as expected) ✅
DELETE /api/v1/patients/{id} → 409 Conflict when encounters exist (correct guarded behaviour) ✅