### PR TITLE
Add endpoint to list active doctors

### DIFF
--- a/code/meditriage-be/app/api/v1/controllers/user_controller.py
+++ b/code/meditriage-be/app/api/v1/controllers/user_controller.py
@@ -7,15 +7,31 @@ from sqlalchemy.orm import Session
 from uuid import UUID
 from typing import List
 from app.db.session import get_db
-from app.api.dependencies import allow_admin
+from app.api.dependencies import allow_admin, allow_all_authenticated
 from app.models.user import User
-from app.schemas.user import UserListResponse
+from app.schemas.user import UserListResponse, DoctorResponse
 from app.schemas.common import DeleteResponse
 from app.services import user_service
 from app.core.logging import get_logger
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/users", tags=["User Management"])
+
+
+@router.get("/doctors", response_model=List[DoctorResponse])
+def list_doctors(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(allow_all_authenticated),
+):
+    """
+    Get list of all active doctors.
+    For dropdowns and triage assignment.
+
+    **Required Role**: Any authenticated user (Nurse, Doctor, Admin)
+    """
+    logger.info(f"Listing active doctors, user={current_user.full_name}")
+    doctors = user_service.list_active_doctors(db)
+    return doctors
 
 
 @router.get("", response_model=List[UserListResponse])

--- a/code/meditriage-be/app/schemas/user.py
+++ b/code/meditriage-be/app/schemas/user.py
@@ -28,3 +28,13 @@ class UserListResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class DoctorResponse(BaseModel):
+    """Response schema for doctor listing."""
+    id: UUID
+    full_name: str
+    license_number: Optional[str]
+
+    class Config:
+        from_attributes = True

--- a/code/meditriage-be/app/services/user_service.py
+++ b/code/meditriage-be/app/services/user_service.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from typing import List
 from sqlalchemy.orm import Session
 from fastapi import HTTPException, status
-from app.models.user import User
+from app.models.user import User, UserRole
 from app.models.auth import Auth
 from app.schemas.user import UserProfileUpdate
 from app.core.logging import get_logger
@@ -30,6 +30,27 @@ def list_users(skip: int, limit: int, db: Session) -> List[User]:
     users = db.query(User).offset(skip).limit(limit).all()
     logger.info(f"Retrieved {len(users)} users (skip={skip}, limit={limit})")
     return users
+
+
+def list_active_doctors(db: Session) -> List[User]:
+    """
+    Get list of all active doctors.
+    For triage assignment.
+    
+    Args:
+        db: Database session
+        
+    Returns:
+        List of active User objects where role is DOCTOR
+    """
+    doctors = (
+        db.query(User)
+        .join(Auth, User.id == Auth.user_id)
+        .filter(User.role == UserRole.DOCTOR, Auth.is_active == True)
+        .all()
+    )
+    logger.info(f"Retrieved {len(doctors)} active doctors")
+    return doctors
 
 
 def update_user_profile(user_id: UUID, data: UserProfileUpdate, db: Session) -> User:


### PR DESCRIPTION
Add GET /users/doctors endpoint returning List[DoctorResponse], protected by allow_all_authenticated so any authenticated user can retrieve active doctors (for dropdowns and triage assignment). Introduce DoctorResponse schema (id, full_name, license_number). Implement user_service.list_active_doctors which queries User joined with Auth and filters by UserRole.DOCTOR and Auth.is_active == True; add logging and update imports accordingly.