### PR TITLE
fix: stamp doctor_id on encounter finalization and return encounter s…

### DIFF
--- a/code/meditriage-be/app/api/v1/controllers/triage_controller.py
+++ b/code/meditriage-be/app/api/v1/controllers/triage_controller.py
@@ -23,6 +23,7 @@ from app.schemas.clinical import (
     ClinicalNoteResponse,
     ClinicalNoteUpdate,
 )
+from app.models.clinical import MedicalEncounter
 from app.services import triage_engine, encounter_service
 from app.core.logging import get_logger
 
@@ -232,6 +233,8 @@ def update_clinical_note(
     """
     Update clinical note (Doctor edits/approves AI draft).
     Increments version and can finalize the note.
+    When finalized, stamps the doctor_id on the encounter and sets
+    encounter status to COMPLETED.
 
     **Required Role**: Doctor only
     """
@@ -239,7 +242,29 @@ def update_clinical_note(
 
     try:
         note = encounter_service.update_clinical_note(encounter_id, data, current_user, db)
-        return note
+
+        # Fetch encounter to attach its (possibly updated) status & doctor to the response
+        encounter = db.query(MedicalEncounter).filter(
+            MedicalEncounter.id == encounter_id
+        ).first()
+
+        # Build a flat ClinicalNoteResponse with the extra fields populated.
+        # encounter_status and doctor_id are Optional on the schema so existing
+        # frontend code reading other fields is unaffected.
+        return ClinicalNoteResponse(
+            id=note.id,
+            encounter_id=note.encounter_id,
+            subjective=note.subjective,
+            objective=note.objective,
+            assessment=note.assessment,
+            plan=note.plan,
+            is_finalized=note.is_finalized,
+            version=note.version,
+            created_at=note.created_at,
+            updated_at=note.updated_at,
+            encounter_status=encounter.status.value if encounter else None,
+            doctor_id=encounter.doctor_id if encounter else None,
+        )
     except HTTPException:
         raise
     except Exception as e:

--- a/code/meditriage-be/app/schemas/clinical.py
+++ b/code/meditriage-be/app/schemas/clinical.py
@@ -100,6 +100,9 @@ class ClinicalNoteResponse(BaseModel):
     version: int
     created_at: datetime
     updated_at: datetime
+    # Extra fields populated only on PUT (update) responses — not present on GET
+    encounter_status: Optional[str] = None   # e.g. "COMPLETED" after finalization
+    doctor_id: Optional[UUID] = None         # who finalized the note
 
     class Config:
         from_attributes = True

--- a/code/meditriage-be/app/services/encounter_service.py
+++ b/code/meditriage-be/app/services/encounter_service.py
@@ -219,12 +219,13 @@ def update_clinical_note(
         if field == "is_finalized" and value:
             # Mark as finalized
             note.is_finalized = True
-            # Update encounter status to COMPLETED
+            # Update encounter status to COMPLETED and stamp the doctor
             encounter = db.query(MedicalEncounter).filter(
                 MedicalEncounter.id == encounter_id
             ).first()
             if encounter:
                 encounter.status = EncounterStatus.COMPLETED
+                encounter.doctor_id = current_user.id  # audit trail: who finalized
         else:
             setattr(note, field, value)
     


### PR DESCRIPTION
…tatus in SOAP note update response
Investigation of the reported issue revealed that the core SOAP editing and finalization functionality was already implemented via PUT /api/v1/triage/{encounter_id}/note. This PR fixes the two actual gaps identified during investigation.

Endpoint Affected:
PUT  /api/v1/triage/{encounter_id}/note

Changes Made
1. 

app/services/encounter_service.py
In 

update_clinical_note()
, when is_finalized=True is received, the acting doctor's ID is now stamped on the MedicalEncounter.doctor_id column
Previously this column was always NULL even after finalization — no audit trail existed of which doctor treated the patient
2. 

app/schemas/clinical.py
Added two optional fields to the existing 

ClinicalNoteResponse
 schema:
encounter_status: Optional[str] — reflects the encounter's updated status after the operation (e.g. "COMPLETED")
doctor_id: Optional[UUID] — the doctor who finalized the note
These fields are None on GET responses and populated on PUT responses — fully backward-compatible, no frontend changes required
3. 

app/api/v1/controllers/triage_controller.py
Updated the PUT /triage/{encounter_id}/note endpoint to explicitly build and return the enriched 

ClinicalNoteResponse
 with encounter_status and doctor_id populated from the encounter record after update
 
 No Breaking Changes
Request body is unchanged
Endpoint URL and method are unchanged
All existing response fields remain at the same level — new fields are additive only