### PR TITLE
Syncing with the latest changes in the main

### DIFF
--- a/code/meditriage-be/app/api/v1/controllers/triage_controller.py
+++ b/code/meditriage-be/app/api/v1/controllers/triage_controller.py
@@ -23,6 +23,7 @@ from app.schemas.clinical import (
     ClinicalNoteResponse,
     ClinicalNoteUpdate,
 )
+from app.models.clinical import MedicalEncounter
 from app.services import triage_engine, encounter_service
 from app.core.logging import get_logger
 
@@ -232,6 +233,8 @@ def update_clinical_note(
     """
     Update clinical note (Doctor edits/approves AI draft).
     Increments version and can finalize the note.
+    When finalized, stamps the doctor_id on the encounter and sets
+    encounter status to COMPLETED.
 
     **Required Role**: Doctor only
     """
@@ -239,7 +242,29 @@ def update_clinical_note(
 
     try:
         note = encounter_service.update_clinical_note(encounter_id, data, current_user, db)
-        return note
+
+        # Fetch encounter to attach its (possibly updated) status & doctor to the response
+        encounter = db.query(MedicalEncounter).filter(
+            MedicalEncounter.id == encounter_id
+        ).first()
+
+        # Build a flat ClinicalNoteResponse with the extra fields populated.
+        # encounter_status and doctor_id are Optional on the schema so existing
+        # frontend code reading other fields is unaffected.
+        return ClinicalNoteResponse(
+            id=note.id,
+            encounter_id=note.encounter_id,
+            subjective=note.subjective,
+            objective=note.objective,
+            assessment=note.assessment,
+            plan=note.plan,
+            is_finalized=note.is_finalized,
+            version=note.version,
+            created_at=note.created_at,
+            updated_at=note.updated_at,
+            encounter_status=encounter.status.value if encounter else None,
+            doctor_id=encounter.doctor_id if encounter else None,
+        )
     except HTTPException:
         raise
     except Exception as e:

--- a/code/meditriage-be/app/schemas/clinical.py
+++ b/code/meditriage-be/app/schemas/clinical.py
@@ -100,6 +100,9 @@ class ClinicalNoteResponse(BaseModel):
     version: int
     created_at: datetime
     updated_at: datetime
+    # Extra fields populated only on PUT (update) responses — not present on GET
+    encounter_status: Optional[str] = None   # e.g. "COMPLETED" after finalization
+    doctor_id: Optional[UUID] = None         # who finalized the note
 
     class Config:
         from_attributes = True

--- a/code/meditriage-be/app/services/encounter_service.py
+++ b/code/meditriage-be/app/services/encounter_service.py
@@ -219,12 +219,13 @@ def update_clinical_note(
         if field == "is_finalized" and value:
             # Mark as finalized
             note.is_finalized = True
-            # Update encounter status to COMPLETED
+            # Update encounter status to COMPLETED and stamp the doctor
             encounter = db.query(MedicalEncounter).filter(
                 MedicalEncounter.id == encounter_id
             ).first()
             if encounter:
                 encounter.status = EncounterStatus.COMPLETED
+                encounter.doctor_id = current_user.id  # audit trail: who finalized
         else:
             setattr(note, field, value)
     


### PR DESCRIPTION
This pull request enhances the clinical note update workflow by ensuring finalized notes are properly audited and that API responses include additional encounter metadata. The main improvements are focused on updating the encounter status and doctor assignment upon note finalization, and returning this enriched information to the frontend.

**Clinical note finalization and encounter auditing:**

* When a clinical note is finalized (via `update_clinical_note`), the corresponding `MedicalEncounter` record is updated to set its status to `COMPLETED` and to record the `doctor_id` of the user who finalized the note, providing a clear audit trail.

**API response enhancements:**

* The `update_clinical_note` controller now returns a `ClinicalNoteResponse` that includes the updated `encounter_status` and `doctor_id` fields, allowing the frontend to immediately reflect these changes without extra requests.
* The `ClinicalNoteResponse` schema in `clinical.py` is extended with optional `encounter_status` and `doctor_id` fields, which are populated only on update (PUT) responses.

**Imports and dependency updates:**

* The `MedicalEncounter` model is now imported in the triage controller to support the new response structure.