### PR TITLE
Add PATCH /api/v1/users/{user_id} — User Profile Update Endpoint

### DIFF
--- a/code/meditriage-be/app/api/v1/controllers/user_controller.py
+++ b/code/meditriage-be/app/api/v1/controllers/user_controller.py
@@ -2,14 +2,14 @@
 User/Staff management API controller.
 Handles staff listing and account management (Admin functions).
 """
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 from uuid import UUID
 from typing import List
 from app.db.session import get_db
 from app.api.dependencies import allow_admin, allow_all_authenticated
-from app.models.user import User
-from app.schemas.user import UserListResponse, DoctorResponse
+from app.models.user import User, UserRole
+from app.schemas.user import UserListResponse, DoctorResponse, UserProfileUpdate
 from app.schemas.common import DeleteResponse
 from app.services import user_service
 from app.core.logging import get_logger
@@ -50,6 +50,53 @@ def list_users(
     logger.info(f"Listing users: skip={skip}, limit={limit}, admin={current_user.full_name}")
     users = user_service.list_users(skip, limit, db)
     return users
+
+
+@router.patch("/{user_id}", response_model=UserListResponse)
+def update_user(
+    user_id: UUID,
+    data: UserProfileUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(allow_all_authenticated),
+):
+    """
+    Update a user's profile (display name, license number).
+
+    **Authorization**: Users may only update their own profile.
+    Admins may update any user's profile.
+
+    **Required Role**: Any authenticated user (self-update), or Admin (any user)
+    """
+    # Enforce self-update unless the caller is an Admin
+    if current_user.id != user_id and current_user.role != UserRole.ADMIN:
+        logger.warning(
+            f"Forbidden profile update attempt: caller_id={current_user.id}, "
+            f"target_id={user_id}, role={current_user.role.value}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only update your own profile"
+        )
+
+    logger.info(
+        f"Updating user profile: target_id={user_id}, "
+        f"caller_id={current_user.id}, role={current_user.role.value}"
+    )
+
+    updated_user = user_service.update_user_profile(user_id, data, db)
+
+    logger.info(f"User profile updated successfully: user_id={user_id}")
+
+    return UserListResponse(
+        id=updated_user.id,
+        username=updated_user.auth.username,
+        email=updated_user.auth.email,
+        full_name=updated_user.full_name,
+        role=updated_user.role,
+        license_number=updated_user.license_number,
+        is_active=updated_user.auth.is_active,
+        created_at=updated_user.created_at,
+    )
 
 
 @router.delete("/{user_id}", response_model=DeleteResponse)


### PR DESCRIPTION
```markdown
## feat: Add `PATCH /api/v1/users/{user_id}` — User Profile Update Endpoint

### Problem
The Doctor and Nurse Settings panes allowed users to edit their display name, but there was no backend endpoint to persist the change. Profile updates were lost on every page reload because nothing was written to the database.

---

### Solution
Added the missing `PATCH /api/v1/users/{user_id}` endpoint to persist `full_name` (and optionally `license_number`) to the [users](cci:1://file:///d:/Software%20system%20design%20project/Meditriage/e22-co2060-MediTriage/code/meditriage-be/app/api/v1/controllers/user_controller.py:36:0-51:16) table.

---

### Files Changed

| File | Change |
|---|---|
| [app/api/v1/controllers/user_controller.py](cci:7://file:///d:/Software%20system%20design%20project/Meditriage/e22-co2060-MediTriage/code/meditriage-be/app/api/v1/controllers/user_controller.py:0:0-0:0) | New endpoint added |

> No other files were changed. The existing [UserProfileUpdate](cci:2://file:///d:/Software%20system%20design%20project/Meditriage/e22-co2060-MediTriage/code/meditriage-be/app/schemas/user.py:11:0-14:62) schema, [update_user_profile()](cci:1://file:///d:/Software%20system%20design%20project/Meditriage/e22-co2060-MediTriage/code/meditriage-be/app/services/user_service.py:55:0-89:15) service, and [UserListResponse](cci:2://file:///d:/Software%20system%20design%20project/Meditriage/e22-co2060-MediTriage/code/meditriage-be/app/schemas/user.py:17:0-29:30) schema were already in place and reused as-is.

---

### New Endpoint

**Request**
```
PATCH /api/v1/users/{user_id}
Authorization: Bearer <token>
Content-Type: application/json

{ "full_name": "Dr. Jane Smith" }
```

**Response `200 OK`**
```json
{
  "id": "...",
  "username": "nurse_jane",
  "email": "jane@hospital.com",
  "full_name": "Dr. Jane Smith",
  "role": "NURSE",
  "license_number": null,
  "is_active": true,
  "created_at": "..."
}
```

---

### Authorization

| Caller | Target | Result |
|---|---|---|
| Nurse / Doctor | Own `user_id` | ✅ `200 OK` |
| Nurse / Doctor | Someone else's `user_id` | ❌ `403 Forbidden` |
| Admin | Any `user_id` | ✅ `200 OK` |

---

### Notes
- ✅ No database migration required — no schema changes
- ✅ No breaking changes to existing endpoints
- ✅ Fixes Settings pane persistence issue for Nurse and Doctor roles
```
