### PR TITLE
Implement-Endpoint-to-Assign-Doctor-to-Encounter

### DIFF
--- a/code/meditriage-be/app/api/v1/controllers/triage_controller.py
+++ b/code/meditriage-be/app/api/v1/controllers/triage_controller.py
@@ -108,6 +108,7 @@ def list_active_encounters(
                 patient_id=e.patient_id,
                 patient_name=f"{e.patient.first_name} {e.patient.last_name}" if e.patient else None,
                 nurse_id=e.nurse_id,
+                doctor_id=e.doctor_id,
                 status=e.status,
                 is_urgent=e.is_urgent,
                 chief_complaint=e.chief_complaint,
@@ -166,33 +167,39 @@ def get_encounter_messages(
 
 
 @router.patch("/{encounter_id}", response_model=EncounterResponse)
-def update_encounter_urgency(
+def update_encounter(
     encounter_id: UUID,
     data: EncounterUpdateRequest,
     db: Session = Depends(get_db),
     current_user: User = Depends(allow_nurse),
 ):
     """
-    Update encounter urgency status.
-    Allows nurse to manually flag urgent cases.
+    Update encounter fields: urgency, assigned doctor, and/or status.
+    Called by the Clinical Summary modal when the nurse assigns a doctor
+    and submits the "Add Patient" action.
+
+    Accepts any combination of: is_urgent, doctor_id, status.
 
     **Required Role**: Nurse
     """
-    logger.info(f"Updating encounter urgency: encounter_id={encounter_id}, is_urgent={data.is_urgent}, nurse={current_user.full_name}")
+    logger.info(
+        f"Updating encounter: encounter_id={encounter_id}, "
+        f"doctor_id={data.doctor_id}, status={data.status}, "
+        f"is_urgent={data.is_urgent}, nurse={current_user.full_name}"
+    )
 
     try:
-        if data.is_urgent is not None:
-            encounter = encounter_service.update_encounter_urgency(encounter_id, data.is_urgent, db)
-            return encounter
-        else:
+        if data.is_urgent is None and data.doctor_id is None and data.status is None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="No update data provided"
             )
+        encounter = encounter_service.update_encounter(encounter_id, data, db)
+        return encounter
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to update encounter urgency: encounter_id={encounter_id}, error={str(e)}", exc_info=True)
+        logger.error(f"Failed to update encounter: encounter_id={encounter_id}, error={str(e)}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to update encounter"

--- a/code/meditriage-be/app/schemas/clinical.py
+++ b/code/meditriage-be/app/schemas/clinical.py
@@ -40,6 +40,7 @@ class EncounterListItem(BaseModel):
     patient_id: UUID
     patient_name: Optional[str] = None   # denormalized from Patient.full_name
     nurse_id: UUID
+    doctor_id: Optional[UUID] = None     # assigned doctor (populated after nurse assigns)
     status: EncounterStatus
     is_urgent: bool
     chief_complaint: Optional[str] = None
@@ -50,8 +51,10 @@ class EncounterListItem(BaseModel):
 
 
 class EncounterUpdateRequest(BaseModel):
-    """Request schema for updating encounter urgency (nurse toggle)."""
+    """Request schema for updating encounter fields (urgency toggle and/or doctor assignment)."""
     is_urgent: Optional[bool] = Field(None, description="Mark encounter as urgent")
+    doctor_id: Optional[UUID] = Field(None, description="Assign a doctor to this encounter")
+    status: Optional[EncounterStatus] = Field(None, description="Update encounter status")
 
 
 # ==================== Triage Interaction Schemas ====================

--- a/code/meditriage-be/app/services/encounter_service.py
+++ b/code/meditriage-be/app/services/encounter_service.py
@@ -150,6 +150,56 @@ def update_encounter_urgency(encounter_id: UUID, is_urgent: bool, db: Session) -
     return encounter
 
 
+def update_encounter(
+    encounter_id: UUID,
+    data: EncounterUpdateRequest,
+    db: Session
+) -> MedicalEncounter:
+    """
+    General-purpose encounter update.
+    Handles any combination of: is_urgent, doctor_id, status.
+    Called by the PATCH /{encounter_id} endpoint from the Clinical Summary modal.
+
+    Args:
+        encounter_id: Encounter UUID
+        data: EncounterUpdateRequest (any subset of fields may be set)
+        db: Database session
+
+    Returns:
+        Updated MedicalEncounter
+
+    Raises:
+        HTTPException: 404 if encounter not found
+    """
+    encounter = db.query(MedicalEncounter).filter(
+        MedicalEncounter.id == encounter_id
+    ).first()
+
+    if not encounter:
+        logger.warning(f"Encounter not found for update: id={encounter_id}")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Encounter with ID {encounter_id} not found"
+        )
+
+    if data.is_urgent is not None:
+        encounter.is_urgent = data.is_urgent
+        logger.info(f"Encounter urgency updated: id={encounter_id}, is_urgent={data.is_urgent}")
+
+    if data.doctor_id is not None:
+        encounter.doctor_id = data.doctor_id
+        logger.info(f"Encounter doctor assigned: id={encounter_id}, doctor_id={data.doctor_id}")
+
+    if data.status is not None:
+        encounter.status = data.status
+        logger.info(f"Encounter status updated: id={encounter_id}, status={data.status}")
+
+    db.commit()
+    db.refresh(encounter)
+
+    return encounter
+
+
 def get_clinical_note(encounter_id: UUID, db: Session) -> Optional[ClinicalNote]:
     """
     Fetch SOAP note for an encounter.


### PR DESCRIPTION
## Fix: Doctor Assignment from Clinical Summary Modal

### Problem
The "Add Patient" action in the Nurse Clinical Summary modal silently failed to save the assigned doctor to the database. The frontend sends:

PATCH /api/v1/triage/{encounter_id}

with body `{ "doctor_id": "...", "status": "AWAITING_REVIEW" }`, but the endpoint ignored both fields because they were not defined in the request schema. As a result, every encounter had `doctor_id = null`, leaving the Doctor Dashboard completely empty.

---

### Root Cause
- [EncounterUpdateRequest](cci:2://file:///d:/Software%20system%20design%20project/Meditriage/e22-co2060-MediTriage/code/meditriage-be/app/schemas/clinical.py:52:0-56:90) schema only had `is_urgent` — `doctor_id` and `status` were silently stripped by Pydantic
- The PATCH handler returned `400 Bad Request` for any request without `is_urgent`
- `GET /api/v1/triage/encounters` did not include `doctor_id` in its response, so the frontend could never read assignments even if they existed

---

### Changes

**[app/schemas/clinical.py](cci:7://file:///d:/Software%20system%20design%20project/Meditriage/e22-co2060-MediTriage/code/meditriage-be/app/schemas/clinical.py:0:0-0:0)**
- [EncounterUpdateRequest](cci:2://file:///d:/Software%20system%20design%20project/Meditriage/e22-co2060-MediTriage/code/meditriage-be/app/schemas/clinical.py:52:0-56:90): added `doctor_id: Optional[UUID]` and `status: Optional[EncounterStatus]`
- [EncounterListItem](cci:2://file:///d:/Software%20system%20design%20project/Meditriage/e22-co2060-MediTriage/code/meditriage-be/app/schemas/clinical.py:36:0-49:30): added `doctor_id: Optional[UUID]`

**[app/services/encounter_service.py](cci:7://file:///d:/Software%20system%20design%20project/Meditriage/e22-co2060-MediTriage/code/meditriage-be/app/services/encounter_service.py:0:0-0:0)**
- Added [update_encounter()](cci:1://file:///d:/Software%20system%20design%20project/Meditriage/e22-co2060-MediTriage/code/meditriage-be/app/services/encounter_service.py:152:0-199:20): persists any combination of `is_urgent`, `doctor_id`, `status`

**[app/api/v1/controllers/triage_controller.py](cci:7://file:///d:/Software%20system%20design%20project/Meditriage/e22-co2060-MediTriage/code/meditriage-be/app/api/v1/controllers/triage_controller.py:0:0-0:0)**
- `PATCH /api/v1/triage/{encounter_id}`: now accepts and saves `doctor_id` + `status`
- `GET /api/v1/triage/encounters`: now returns `doctor_id` per encounter

---

### Endpoints Changed

| Method | Endpoint | What Changed |
|--------|----------|-------------|
| `PATCH` | `/api/v1/triage/{encounter_id}` | Now accepts `doctor_id` and `status` in request body |
| `GET` | `/api/v1/triage/encounters` | Response now includes `doctor_id` field per encounter |

---

### Testing
- `PATCH /api/v1/triage/{encounter_id}` with `{ "doctor_id": "...", "status": "AWAITING_REVIEW" }` → `200 OK`, `doctor_id` persisted in DB ✅
- `GET /api/v1/triage/encounters` → `doctor_id` now populated in response ✅
- Urgency toggle `{ "is_urgent": true }` → still works, no regression ✅

**No database migrations required.** The `doctor_id` column already exists on the `medical_encounters` table.
