### PR TITLE
fixed(issue 82 ): include assigned doctor's full name in encounter li…

### DIFF
--- a/code/meditriage-be/app/api/v1/controllers/triage_controller.py
+++ b/code/meditriage-be/app/api/v1/controllers/triage_controller.py
@@ -109,6 +109,10 @@ def list_active_encounters(
                 patient_name=f"{e.patient.first_name} {e.patient.last_name}" if e.patient else None,
                 nurse_id=e.nurse_id,
                 doctor_id=e.doctor_id,
+                doctor_name=(
+                    e.doctor.full_name[4:].strip() if e.doctor and e.doctor.full_name.startswith("Dr. ")
+                    else e.doctor.full_name if e.doctor else None
+                ),
                 status=e.status,
                 is_urgent=e.is_urgent,
                 chief_complaint=e.chief_complaint,

--- a/code/meditriage-be/app/schemas/clinical.py
+++ b/code/meditriage-be/app/schemas/clinical.py
@@ -41,6 +41,7 @@ class EncounterListItem(BaseModel):
     patient_name: Optional[str] = None   # denormalized from Patient.full_name
     nurse_id: UUID
     doctor_id: Optional[UUID] = None     # assigned doctor (populated after nurse assigns)
+    doctor_name: Optional[str] = None    # assigned doctor full name
     status: EncounterStatus
     is_urgent: bool
     chief_complaint: Optional[str] = None

--- a/code/meditriage-be/app/services/encounter_service.py
+++ b/code/meditriage-be/app/services/encounter_service.py
@@ -4,7 +4,7 @@ Business logic for medical encounters, clinical notes, and triage workflow manag
 """
 from uuid import UUID
 from typing import Tuple, List, Optional
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from fastapi import HTTPException, status
 from app.models.clinical import MedicalEncounter, TriageInteraction, ClinicalNote, EncounterStatus, SenderType
 from app.models.user import User, UserRole
@@ -39,6 +39,7 @@ def get_active_encounters(db: Session) -> List[MedicalEncounter]:
     ]
     encounters = (
         db.query(MedicalEncounter)
+        .options(joinedload(MedicalEncounter.doctor))
         .filter(MedicalEncounter.status.in_(active_statuses))
         .order_by(
             MedicalEncounter.is_urgent.desc(),          # urgent first


### PR DESCRIPTION
…st response

The frontend currently displays "Assigned" or "Unassigned" for the Attending Physician because the `EncounterListItem` schema only included the `doctor_id`.

This commit updates the GET /api/v1/triage/encounters endpoint to resolve the doctor's full name:
- Added `doctor_name: Optional[str]` field to the `EncounterListItem` schema.
- Optimized the database query in `encounter_service.py` using `joinedload` to eagerly load the doctor (User) relationship and avoid N+1 queries.
- Mapped the doctor's name in `triage_controller.py`, stripping redundant "Dr. " prefixes from the database string to prevent "Dr. Dr." display issues in the frontend UI.

@NithikaNB 